### PR TITLE
Refactor all of the money.new stuff to use number_to_currency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 /node_modules
 /yarn-error.log
 
+coverage
+
 .byebug_history
 
 # Ignore application configuration

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -26,11 +26,11 @@ class Cart
     total = contents.reduce(0) do |total, item|
       total += Item.find(item[0]).price * count_of(item[0])
     end
-    "$#{Money.new(total, "USD")}"
+    total / 100
   end
 
   def subtotal(item_id)
-    "$#{Money.new(Item.find(item_id).price * count_of(item_id), "USD")}"
+    (Item.find(item_id).price * count_of(item_id)) / 100
   end
 
   def remove_item(item_id)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,8 @@ class Item < ApplicationRecord
   enum status: [:active, :retired]
 
   def to_money
-    "$#{Money.new(price, "USD")}"
+    price / 100
+    # "$#{Money.new(price, "USD")}"
   end
 
   def set_image

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -32,7 +32,7 @@ class Item < ApplicationRecord
   end
 
   def price_for_item_at_order
-    "#{Money.new(order_items.first.item_price_record)}"
+    order_items.first.item_price_record / 100
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,7 +25,10 @@ class Item < ApplicationRecord
   end
 
   def self.by_popularity
-    select('items.*, count(order_items.id) as order_items_count').joins(:order_items).group(:id).order('order_items_count DESC')
+    select('items.*, count(order_items.id) as order_items_count')
+    .joins(:order_items)
+    .group(:id)
+    .order('order_items_count DESC')
   end
 
   def price_for_item_at_order

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,6 @@ class Item < ApplicationRecord
 
   def to_money
     price / 100
-    # "$#{Money.new(price, "USD")}"
   end
 
   def set_image

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -33,7 +33,9 @@ class Item < ApplicationRecord
   end
 
   def price_for_item_at_order
-    order_items.first.item_price_record / 100
+    order_items
+    .first
+    .item_price_record / 100
   end
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -29,7 +29,7 @@ class Order < ApplicationRecord
   end
 
   def item_total_when_ordered(item_id)
-     "$#{Money.new((get_quantity(item_id) * order_items.find_by(item_id: item_id).item_price_record))}"
+    get_quantity(item_id) * order_items.find_by(item_id: item_id).item_price_record
   end
 
   def total_price_when_ordered

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -33,6 +33,6 @@ class Order < ApplicationRecord
   end
 
   def total_price_when_ordered
-    "$#{Money.new(order_items.sum(:item_price_record))}"
+    order_items.sum(:item_price_record)
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,7 +9,7 @@ class Order < ApplicationRecord
   enum status: [:ordered, :paid, :cancelled, :completed]
 
   def total_price
-    "$#{Money.new(items.sum(:price))}"
+    items.sum(:price) / 100
   end
 
   def get_quantity(id)
@@ -17,7 +17,7 @@ class Order < ApplicationRecord
   end
 
   def get_item_total(item_id)
-    "$#{Money.new((get_quantity(item_id) * items.find(item_id).price))}"
+    (get_quantity(item_id) * items.find(item_id).price) / 100
   end
 
   def total_quantity

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -29,10 +29,10 @@ class Order < ApplicationRecord
   end
 
   def item_total_when_ordered(item_id)
-    get_quantity(item_id) * order_items.find_by(item_id: item_id).item_price_record
+    get_quantity(item_id) * order_items.find_by(item_id: item_id).item_price_record / 100
   end
 
   def total_price_when_ordered
-    order_items.sum(:item_price_record)
+    order_items.sum(:item_price_record) / 100
   end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,7 +5,7 @@ class OrderItem < ApplicationRecord
   before_create :item_price_at_order
 
   def item_price_at_order
-    item_price_record = item.price
+    self.item_price_record = item.price
   end
 
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,7 +5,7 @@ class OrderItem < ApplicationRecord
   before_create :item_price_at_order
 
   def item_price_at_order
-    self.item_price_record = item.price
+    item_price_record = item.price
   end
 
 end

--- a/app/views/admin/base/dashboard.html.erb
+++ b/app/views/admin/base/dashboard.html.erb
@@ -40,7 +40,7 @@
               <td><%= order.user.name %></td>
               <td><a><%= link_to order.created_at.strftime('%a %b %e %Y %H:%M'), admin_order_path(order) %></a></td>
               <td><%= order.total_quantity %></td>
-              <td><%= order.total_price_when_ordered %></td>
+              <td><%= number_to_currency(order.total_price_when_ordered) %></td>
               <td><%= order.status %></td>
               <td><% if order.paid? || order.ordered? %>
                 <%= link_to("cancel order", admin_order_path(order, status: "cancelled"), method: :patch, class: "order#{order.id}") %><br>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -15,7 +15,7 @@
     <tbody>
       <td><a><%= link_to item.name, item_path(item) %></a></td>
       <td><%= image_tag item.image, width: '75px' %></td>
-      <td><%= item.price %></td>
+      <td><%= number_to_currency(item.price) %></td>
       <td><%= truncate(item.description) %></td>
       <td><%= item.status %></td>
       <td><a><%= link_to "Edit", edit_admin_item_path(item) %></a></td>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -15,7 +15,7 @@
     <tbody>
       <td><a><%= link_to item.name, item_path(item) %></a></td>
       <td><%= image_tag item.image, width: '75px' %></td>
-      <td><%= number_to_currency(item.price) %></td>
+      <td><%= number_to_currency(item.to_money) %></td>
       <td><%= truncate(item.description) %></td>
       <td><%= item.status %></td>
       <td><a><%= link_to "Edit", edit_admin_item_path(item) %></a></td>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -23,9 +23,9 @@
             <tbody>
               <tr>
                 <td><%= link_to item.name.titleize, item_path(item) %></td>
-                <td><%= item.price_for_item_at_order %></td>
+                <td><%= number_to_currency(item.price_for_item_at_order) %></td>
                 <td><%= @order.get_quantity(item.id) %></td>
-                <td><%= @order.item_total_when_ordered(item.id) %></td>
+                <td><%= number_to_currency(@order.item_total_when_ordered(item.id)) %></td>
               </tr>
             </tbody>
           <% end %>

--- a/app/views/carts/show.erb
+++ b/app/views/carts/show.erb
@@ -24,7 +24,7 @@
       <td><%= truncate(item.description) %></td>
       <td><%= link_to '<i class="material-icons">remove</i>'.html_safe, cart_path(@cart, button: {item_id: item.id, do: "subtract"}), method: 'patch' %> <%= @cart.count_of(item.id) %> <%= link_to '<i class="material-icons">add</i>'.html_safe, cart_path(@cart, button: {item_id: item.id, do: "add"}), method: 'patch' %></td>
       <td><%= number_to_currency(item.to_money) %></td>
-      <td><%= @cart.subtotal(item.id) %></td>
+      <td><%= number_to_currency(@cart.subtotal(item.id)) %></td>
     </tr>
   </tbody>
   <% end %>
@@ -35,7 +35,7 @@
       <td></td>
       <td></td>
       <td></td>
-      <td>Order Total: <%= @cart.total_cost %> </td>
+      <td>Order Total: <%= number_to_currency(@cart.total_cost) %> </td>
       <td><% if current_user %>
               <%= link_to 'Checkout', orders_path, class: "waves-effect waves-light btn", method: 'post' %>
             <% else %>

--- a/app/views/carts/show.erb
+++ b/app/views/carts/show.erb
@@ -23,7 +23,7 @@
       <td><%= link_to item.name.titleize, item_path(item) %></td>
       <td><%= truncate(item.description) %></td>
       <td><%= link_to '<i class="material-icons">remove</i>'.html_safe, cart_path(@cart, button: {item_id: item.id, do: "subtract"}), method: 'patch' %> <%= @cart.count_of(item.id) %> <%= link_to '<i class="material-icons">add</i>'.html_safe, cart_path(@cart, button: {item_id: item.id, do: "add"}), method: 'patch' %></td>
-      <td><%= item.to_money %></td>
+      <td><%= number_to_currency(item.to_money) %></td>
       <td><%= @cart.subtotal(item.id) %></td>
     </tr>
   </tbody>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -23,7 +23,7 @@
         <% end %>
 
       <div class="card-content">
-        <span class="card-title activator grey-text text-darken-4"><%= link_to item.name.titleize, item_path(item) %><br><%= item.to_money %></span>
+        <span class="card-title activator grey-text text-darken-4"><%= link_to item.name.titleize, item_path(item) %><br><%= number_to_currency(item.to_money) %></span>
       </div>
       <div class="card-reveal">
         <span class="card-title grey-text text-darken-4"><%= item.name %><i class="material-icons right">close</i></span>

--- a/app/views/items/show.erb
+++ b/app/views/items/show.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="card-content">
         <p><%= @item.description %></p><br>
-        <p><%= @item.to_money %></p>
+        <p><%= number_to_currency(@item.to_money) %></p>
         <p>Status: <%= @item.status.titleize %></p><br>
         <p>Tags:</p>
         <% @item.tags.each do |tag| %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -23,7 +23,7 @@
           <tr>
             <td><a><%= link_to order.created_at.strftime('%a %b %e %Y %H:%M'), order_path(order) %></a></td>
             <td><%= order.total_quantity %></td>
-            <td><%= order.total_price_when_ordered %></td>
+            <td><%= number_to_currency(order.total_price_when_ordered) %></td>
             <td><%= order.status %></td>
           </tr>
         </tbody>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -23,8 +23,8 @@
       <td><%= link_to item.name.titleize, item_path(item) %></td>
       <td><%= truncate(item.description) %></td>
       <td><%= @order.get_quantity(item.id) %></td>
-      <td><%= item.price_for_item_at_order %></td>
-      <td><%= @order.item_total_when_ordered(item.id) %></td>
+      <td><%= number_to_currency(item.price_for_item_at_order) %></td>
+      <td><%= number_to_currency(@order.item_total_when_ordered(item.id)) %></td>
     </tr>
   </tbody>
   <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -38,7 +38,7 @@
       <td><% if @order.completed? || @order.cancelled? %>
       <%= @order.updated_at.strftime('%a %b %e %Y %H:%M') %>
     <% end %></td>
-      <td>Order Total: <%= @order.total_price_when_ordered %></td>
+      <td>Order Total: <%= number_to_currency(@order.total_price_when_ordered) %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -12,7 +12,7 @@
         Sorry, this item has been retired.
         <% end %>
       <div class="card-content">
-        <span class="card-title activator grey-text text-darken-4"><%= link_to item.name.capitalize, item_path(item) %><br><%= item.to_money %></span>
+        <span class="card-title activator grey-text text-darken-4"><%= link_to item.name.capitalize, item_path(item) %><br><%= number_to_currency(item.to_money) %></span>
       </div>
       <div class="card-reveal">
         <span class="card-title grey-text text-darken-4"><%= item.name %><i class="material-icons right">close</i></span>

--- a/spec/features/admin/admin_can_view_individual_orders_spec.rb
+++ b/spec/features/admin/admin_can_view_individual_orders_spec.rb
@@ -16,8 +16,7 @@ feature 'Admin' do
       expect(page).to have_content(order.user.name)
       expect(page).to have_content(order.user.address)
       expect(page).to have_content(order.get_quantity(order.items.first.id))
-      expect(page).to have_content(order.get_item_total(order.items.first.id))
-      expect(page).to have_content(order.items.first.to_money)
+      expect(page).to have_content("$0.05")
       expect(page).to have_content(order.status)
     end
   end

--- a/spec/features/orders/user_can_view_single_order_page_spec.rb
+++ b/spec/features/orders/user_can_view_single_order_page_spec.rb
@@ -23,10 +23,10 @@ RSpec.feature "user can view single order" do
     expect(current_path).to eq(order_path(order))
     expect(page).to have_content(item.name)
     expect(page).to have_content(item.description)
-    expect(page).to have_content(item.to_money)
+    expect(page).to have_content("$0.05")
     expect(page).to have_content(order.status)
     expect(page).to have_content(item.description)
     expect(page).to have_content(order.created_at.strftime('%a %b %e %Y %H:%M'))
-    expect(page).to have_content("$15.00")
+    expect(page).to have_content("$0.15")
   end
 end

--- a/spec/features/orders/user_can_view_single_order_page_spec.rb
+++ b/spec/features/orders/user_can_view_single_order_page_spec.rb
@@ -27,6 +27,6 @@ RSpec.feature "user can view single order" do
     expect(page).to have_content(order.status)
     expect(page).to have_content(item.description)
     expect(page).to have_content(order.created_at.strftime('%a %b %e %Y %H:%M'))
-    expect(page).to have_content(order.total_price)
+    expect(page).to have_content("$15.00")
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Item, type: :model do
     it '#to_money' do
       item = create(:item)
 
-      expect(item.to_money).to eq('$0.05')
+      expect(item.to_money).to eq(0.05)
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -8,27 +8,27 @@ RSpec.describe Order, type: :model do
       user = create(:user)
       order = create(:order, user: user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(:user)
-              
+
       expect(order.status).to eq('ordered')
       order.paid!
       expect(order.status).to eq('paid')
     end
-    
+
     it "can change status" do
       user = create(:user)
       order = create(:order, user: user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(:user)
-              
+
       expect(order.status).to eq('ordered')
       order.paid!
       expect(order.status).to eq('paid')
     end
-    
+
     it "can change status again" do
       user = create(:user)
       order = create(:order, user: user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(:user)
-              
+
       expect(order.status).to eq('ordered')
       order.paid!
       expect(order.status).to eq('paid')
@@ -37,7 +37,7 @@ RSpec.describe Order, type: :model do
     end
 
   end
-  
+
   describe "Instance Methods" do
     it '#total_price' do
       user = create(:user)
@@ -45,9 +45,9 @@ RSpec.describe Order, type: :model do
       item_list = create_list(:item, 3)
       # tag.items << item_list
       order.items << item_list
-      expect(order.total_price).to eq('$0.15')
+      expect(order.total_price).to eq(0.15)
     end
-    
+
     it '#get_quantity' do
       user = create(:user)
       order = create(:order, user: user)
@@ -56,14 +56,14 @@ RSpec.describe Order, type: :model do
 
       expect(order.get_quantity(order.id)).to eq(1)
     end
-    
+
     it '#get_item_total' do
       user = create(:user)
       order = create(:order, user: user)
       item_list = create_list(:item, 5)
       order.items << item_list
 
-      expect(order.get_item_total(order.items.first.id)).to eq('$0.05')
+      expect(order.get_item_total(order.items.first.id)).to eq(0.05)
     end
 
   end


### PR DESCRIPTION
I cleaned up a lot of the tests and all of the references to money.new to use number_to_currency.  This should make it easier to refactor the logic of the cart and the item show pages.  I kept the to_money method on items, since it is in so many places and will need to stick around for the time being.  I don't like the to_money method name, but since the prices are stored in cents in the DB, we will need some method like it to divide the price by 100 before passing it to our views.

I might have missed a few of the prices that weren't set to be a dollar amount. I don't think the tests cover all of the instances of prices being used, so we will need to review the site itself through rails s to catch any I may have missed.