### PR TITLE
user_sees_vendor_item_in_cart_or_order_belong_to_test_and_build

### DIFF
--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -9,6 +9,7 @@
       <th></th>
       <th>Item Image</th>
       <th>Item Name</th>
+      <th>Vendor</th>
       <th>Item Description</th>
       <th>Item Quantity</th>
       <th>Item Price</th>
@@ -21,6 +22,7 @@
       <td></td>
       <td><%= image_tag item.image, width: '75px' %></td>
       <td><%= link_to item.name.titleize, item_path(item) %></td>
+      <td><%= item.vendor.name %></td>
       <td><%= truncate(item.description) %></td>
       <td><%= @order.get_quantity(item.id) %></td>
       <td><%= number_to_currency(item.price_for_item_at_order) %></td>

--- a/spec/features/items/user_can_add_an_item_to_cart_spec.rb
+++ b/spec/features/items/user_can_add_an_item_to_cart_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 feature "As a user visiting the site" do
   context "and clicks on the add to cart button" do
     scenario "the item is added to the cart" do
@@ -10,9 +12,13 @@ feature "As a user visiting the site" do
       expect(page).to have_content("You now have 1 #{item1.name}.")
     end
   end
+
   context "and adds items to the cart" do
     scenario "visits cart and sees items" do
       item1 = create(:item)
+      vendor1 = create(:vendor)
+      vendor2 = create(:vendor)
+      vendor1.items << item1
 
       visit items_path
 
@@ -26,9 +32,9 @@ feature "As a user visiting the site" do
 
       expect(page).to have_content(item1.name)
       expect(page).to have_content(Money.new(item1.price, "USD"))
-
       expect(page).to have_content("Order Total:")
-
+      expect(page).to have_content(vendor1.name)
+      expect(page).to_not have_content(vendor2.name)
     end
   end
 end

--- a/spec/features/orders/user_can_view_single_order_page_spec.rb
+++ b/spec/features/orders/user_can_view_single_order_page_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "user can view single order" do
+feature "user can view single order" do
   scenario "from orders page" do
     user = create(:user)
     visit root_path
@@ -10,18 +10,23 @@ RSpec.feature "user can view single order" do
     click_on("Log in")
 
     order = create(:order, user: user)
-    item = create(:item)
-    item2 = create(:item)
+    vendor = create(:vendor)
+    item = create(:item, vendor_id: vendor.id)
+    item2 = create(:item, vendor_id: vendor.id)
     2.times do
       order.items << item
     end
+
     order.items << item2
+
     visit orders_path
 
     click_on order.created_at.strftime('%a %b %e %Y %H:%M')
 
     expect(current_path).to eq(order_path(order))
+
     expect(page).to have_content(item.name)
+    expect(page).to have_content(vendor.name)
     expect(page).to have_content(item.description)
     expect(page).to have_content("$0.05")
     expect(page).to have_content(order.status)


### PR DESCRIPTION
#### Issue Number: user_sees_vendor_item_in_cart_or_order_belong_to_test_and_build

#### Description of changes:
* tests modified to view vendor name with each item:
+ ./spec/features/orders/user_can_view_single_order_page_spec.rb
+ ./spec/features/items/user_can_add_an_item_to_cart_spec.rb
* views modified to accommodate:
+ app/views/orders/show.html.erb
+ app/views/carts/show.erb

Notes: I expect to need this functionality added to Admin related portions of the app as well, in another iteration.

#### @mentions of the person or team responsible for reviewing proposed changes:
Joel Lindow